### PR TITLE
Using `unzip` tool instead `ZIPFoundation`, to fix "This file was downloaded on an unknown date. " report

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,12 +13,10 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "0.3.0"),
-        .package(url: "https://github.com/weichsel/ZIPFoundation.git", .upToNextMajor(from: "0.9.0"))
     ],
     targets: [
         .target(name: "ios2m1", dependencies: [
             .product(name: "ArgumentParser", package: "swift-argument-parser"),
-            "ZIPFoundation"
         ])
     ]
 )

--- a/Sources/ios2m1/main.swift
+++ b/Sources/ios2m1/main.swift
@@ -1,6 +1,5 @@
 import Foundation
 import ArgumentParser
-import ZIPFoundation
 
 struct ios2m1: ParsableCommand {
     
@@ -70,7 +69,9 @@ struct ios2m1: ParsableCommand {
             try deleteFolder(at: payloadFolder)
             
             print("Unzipping ipa...")
-            try FileManager.default.unzipItem(at: inputUrl, to: workFolder)
+            
+            /// using unzip instead.
+            shell("unzip -oq \(inputUrl.path) -d \(workFolder.path)")
             
             /// Get .app folder inside Payload
             let payloadContents = try FileManager.default.contentsOfDirectory(at: payloadFolder, includingPropertiesForKeys: nil)


### PR DESCRIPTION
Thanks for your tool. 
But this tool did not work well on macOS 12.5 while I was trying to convert `.ipa` into `.app`. 
I'm guessing it's because some files or dirs attributes was lost during zip extraction. 
So I roughly fixed this issue by using `unzip`, and waiting for more precise reason and solution :)